### PR TITLE
Add UNMIRI NGS interpretation schema (FHIR-Genomics-aligned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ The following systems provide support for automated testing of FHIR clients and/
 
 ### JSON Schema
 
+* [unmiri-ngs-fhir-schema](https://github.com/unmirihealth/unmiri-ngs-fhir-schema) - Apache-2.0 JSON Schema (Draft 2020-12) API contract for cross-vendor somatic NGS interpretation output (Foundation Medicine, Tempus, Caris, Guardant), shaped to align with the HL7 FHIR Genomics IG. Includes TypeScript/Python types, worked examples, and a validator.
+
 ### CDS Hooks
 
 ### Bulk Data


### PR DESCRIPTION
Adds an entry under the (currently empty) JSON Schema section.

UNMIRI's unmiri-ngs-fhir-schema is an Apache-2.0 JSON Schema (Draft 2020-12) API contract for cross-vendor somatic NGS interpretation output, shaped to align with the HL7 FHIR Genomics Implementation Guide.

It is a developer-ergonomic data contract (JSON Schema + TypeScript + Python pydantic), not a literal FHIR Bundle profile. It covers variants, biomarkers, companion-diagnostic flags, trial matches, and contraindications, and ships worked synthetic examples plus a validator.
